### PR TITLE
Adding more modules to proxy

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,9 +5,10 @@
 </head>
 <body>
   <div id="photo-gallery"></div>
-  <div id="reviews"></div>
   <div id="checkout"></div>
+  <div id="reviews"></div>
   <div id="recommendations"></div>
+  <div id="experiences"></div>
   <script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin></script>
   <script src="//unpkg.com/styled-components/dist/styled-components.min.js"></script>
@@ -15,5 +16,6 @@
   <script src="http://localhost:3002/bundle.js"></script>
   <script src="http://localhost:3003/bundle.js"></script>
   <script src="http://localhost:3004/bundle.js"></script>
+  <script src="http://localhost:3005/:listingid/bundle.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -13,9 +13,9 @@
   <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin></script>
   <script src="//unpkg.com/styled-components/dist/styled-components.min.js"></script>
   <script src="http://localhost:3001/:listingid/bundle.js"></script>
-  <script src="http://localhost:3002/bundle.js"></script>
+  <!-- <script src="http://localhost:3002/bundle.js"></script> -->
   <script src="http://localhost:3003/bundle.js"></script>
   <script src="http://localhost:3004/bundle.js"></script>
-  <script src="http://localhost:3005/:listingid/bundle.js"></script>
+  <script src="http://localhost:3005/bundle.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -5,11 +5,13 @@
 </head>
 <body>
   <div id="photo-gallery"></div>
-  <div id="app"></div>
+  <div id="reviews"></div>
+  <div id="checkout"></div>
   <script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin></script>
   <script src="//unpkg.com/styled-components/dist/styled-components.min.js"></script>
   <script src="http://localhost:3001/:listingid/bundle.js"></script>
+  <script src="http://localhost:3002/bundle.js"></script>
   <script src="http://localhost:3003/bundle.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,11 +1,14 @@
 <!doctype html>
 <head>
   <title>o2znz</title>
+  <link rel="stylesheet" type="text/css" href="./styles.css" />
 </head>
 <body>
   <div id="photo-gallery"></div>
+  <div id="app"></div>
   <script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin></script>
+  <script src="http://localhost:3003/bundle.js"></script>
   <script src="http://localhost:3001/:listingid/bundle.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -7,11 +7,13 @@
   <div id="photo-gallery"></div>
   <div id="reviews"></div>
   <div id="checkout"></div>
+  <div id="recommendations"></div>
   <script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin></script>
   <script src="//unpkg.com/styled-components/dist/styled-components.min.js"></script>
   <script src="http://localhost:3001/:listingid/bundle.js"></script>
   <script src="http://localhost:3002/bundle.js"></script>
   <script src="http://localhost:3003/bundle.js"></script>
+  <script src="http://localhost:3004/bundle.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,8 @@
   <div id="app"></div>
   <script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin></script>
-  <script src="http://localhost:3003/bundle.js"></script>
+  <script src="//unpkg.com/styled-components/dist/styled-components.min.js"></script>
   <script src="http://localhost:3001/:listingid/bundle.js"></script>
+  <script src="http://localhost:3003/bundle.js"></script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,46 @@
+/* CSS reset from
+http://meyerweb.com/eric/tools/css/reset/ (public domain) */
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const app = express();
 const port = 3000;
-const path = require('path');
 
 app.use('/:listingid', express.static('public'));
 


### PR DESCRIPTION
- add reset css sheet, link to from proxy's index.html file
- import styled components to proxy's index.html file
- add div & import statement for 4 additional modules in proxy's index.html file

Note, in order for the proxy to render all components to the page, this update requires the following changes in other modules:
- updating id of the div that a module is rendering to to (i.e. not 'app')
- adding CORS headers in a module's server (for reference see https://github.com/O2znz/photo-gallery/pull/10)
- hard-coding the URL of the get request on component mount for a module (for reference see https://github.com/O2znz/photo-gallery/pull/10, although I passed the url in as a prop but I probably didn't need to do that, it can be put in the component itself)
- replacing import statements in styled component/react component files with `const styled = window.styled;` or equivalent (for reference see https://github.com/O2znz/photo-gallery/pull/11)
- port numbers for every module are mutually exclusive
- importing react and styled-components in the index.html file of a module (this might be optional)